### PR TITLE
fix(test): correct tmp path for testing

### DIFF
--- a/shadowsocks-csharp/Encryption/MbedTLS.cs
+++ b/shadowsocks-csharp/Encryption/MbedTLS.cs
@@ -65,7 +65,8 @@ namespace Shadowsocks.Encryption
 
         static MbedTLS()
         {
-            string runningPath = Path.Combine(System.Windows.Forms.Application.StartupPath, @"temp"); // Path.GetTempPath();
+            string path = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            string runningPath = Path.Combine(new Uri(path).LocalPath, @"temp"); // Path.GetTempPath();
             if (!Directory.Exists(runningPath))
             {
                 Directory.CreateDirectory(runningPath);


### PR DESCRIPTION
fix access denials when `MbedTLS` try to make the temp directory.