### PR TITLE
Partially fix #54.

### DIFF
--- a/shadowsocks-csharp/Program.cs
+++ b/shadowsocks-csharp/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using System.Threading;
 using System.Windows.Forms;
 using Microsoft.Win32;
@@ -56,8 +57,9 @@ namespace Shadowsocks
                 }
 #endif
                 Directory.SetCurrentDirectory(Application.StartupPath);
-#if !_CONSOLE
+
                 int try_times = 0;
+#if !_CONSOLE
                 while (Configuration.Load() == null)
                 {
                     if (try_times >= 5)
@@ -79,6 +81,13 @@ namespace Shadowsocks
                 //#endif
                 _controller = new ShadowsocksController();
                 HostMap.Instance().LoadHostFile();
+
+#if _DOTNET_CURRENT
+                // Enable Modern TLS when .NET 4.5+ installed.
+                if (Util.EnvCheck.CheckDotNet45())
+                    ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
+#endif
+
 #if !_CONSOLE
                 _viewController = new MenuViewController(_controller);
 #endif

--- a/shadowsocks-csharp/Util/EnvCheck.cs
+++ b/shadowsocks-csharp/Util/EnvCheck.cs
@@ -8,13 +8,13 @@ namespace Shadowsocks.Util
     {
         // According to https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
         // Hard code the path in Registry.
-        private static string dotNet45Registry = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full";
+        private static string dotNet45Registry = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\x1";
 
         public static bool CheckDotNet45()
         {
             Int32 installed = Convert.ToInt32(Registry.GetValue(dotNet45Registry, "Release", 0));
             if (0 == installed)
-                throw new SystemException(String.Format("Cannot find .NET version from registry path: {0}.", dotNet45Registry));
+                return false;
 
             if (378389 <= installed)
                 return true;

--- a/shadowsocks-csharp/Util/EnvCheck.cs
+++ b/shadowsocks-csharp/Util/EnvCheck.cs
@@ -8,7 +8,7 @@ namespace Shadowsocks.Util
     {
         // According to https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
         // Hard code the path in Registry.
-        private static string dotNet45Registry = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\x1";
+        private static string dotNet45Registry = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full";
 
         public static bool CheckDotNet45()
         {

--- a/shadowsocks-csharp/Util/EnvCheck.cs
+++ b/shadowsocks-csharp/Util/EnvCheck.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Windows.Forms;
+using Microsoft.Win32;
+
+namespace Shadowsocks.Util
+{
+    public class EnvCheck
+    {
+        // According to https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
+        // Hard code the path in Registry.
+        private static string dotNet45Registry = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full";
+
+        public static bool CheckDotNet45()
+        {
+            Int32 installed = Convert.ToInt32(Registry.GetValue(dotNet45Registry, "Release", 0));
+            if (0 == installed)
+                throw new SystemException(String.Format("Cannot find .NET version from registry path: {0}.", dotNet45Registry));
+
+            if (378389 <= installed)
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/shadowsocks-csharp/shadowsocks-csharp4.0.csproj
+++ b/shadowsocks-csharp/shadowsocks-csharp4.0.csproj
@@ -43,7 +43,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\4.0\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;_DOTNET_4_0, PROTOCOL_STATISTICS</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;_DOTNET_CURRENT, PROTOCOL_STATISTICS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -181,6 +181,7 @@
     </Compile>
     <Compile Include="Util\Base64.cs" />
     <Compile Include="Util\CRC.cs" />
+    <Compile Include="Util\EnvCheck.cs" />
     <Compile Include="Util\ServerName.cs" />
     <Compile Include="Util\Util.cs" />
     <Compile Include="View\ConfigForm.cs">

--- a/shadowsocks-csharp/shadowsocks-csharp4.0.csproj
+++ b/shadowsocks-csharp/shadowsocks-csharp4.0.csproj
@@ -43,7 +43,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\4.0\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;_DOTNET_CURRENT, PROTOCOL_STATISTICS</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;_DOTNET_4_0, _DOTNET_CURRENT, PROTOCOL_STATISTICS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -53,9 +53,9 @@
     <Compile Include="ServerTest.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\shadowsocks-csharp\shadowsocks-csharp.csproj">
-      <Project>{8c02d2f7-7cdb-4d55-9f25-cd03ef4aa062}</Project>
-      <Name>shadowsocks-csharp</Name>
+    <ProjectReference Include="..\shadowsocks-csharp\shadowsocks-csharp4.0.csproj">
+      <Project>{0f2a0c8a-6c06-485b-aa13-aeec19ca9637}</Project>
+      <Name>shadowsocks-csharp4.0</Name>
     </ProjectReference>
   </ItemGroup>
   <Choose>


### PR DESCRIPTION
- Enable modern TLS when .NET Framework >=4.5 detected.
  Note: Only for clients built with .NET Framework >= 4.0.

Note here: Along with Pull Request #74 , for it cannot compile unless I move the line outside.