### PR TITLE
[Bug Fix] Add null check into "Import servers from file..." menu item 

### DIFF
--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -943,7 +943,7 @@ namespace Shadowsocks.View
                 {
                     string name = dlg.FileName;
                     Configuration cfg = Configuration.LoadFile(name);
-                    if (cfg is null || (cfg.configs.Count == 1 && cfg.configs[0].server == Configuration.GetDefaultServer().server))
+                    if (cfg == null || (cfg.configs.Count == 1 && cfg.configs[0].server == Configuration.GetDefaultServer().server))
                     {
                         MessageBox.Show("Load config file failed", "ShadowsocksR");
                     }

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -943,7 +943,7 @@ namespace Shadowsocks.View
                 {
                     string name = dlg.FileName;
                     Configuration cfg = Configuration.LoadFile(name);
-                    if (cfg.configs.Count == 1 && cfg.configs[0].server == Configuration.GetDefaultServer().server)
+                    if (cfg is null || (cfg.configs.Count == 1 && cfg.configs[0].server == Configuration.GetDefaultServer().server))
                     {
                         MessageBox.Show("Load config file failed", "ShadowsocksR");
                     }


### PR DESCRIPTION
Hi,
We found an issue that if import an invalid config file by the "Import servers from file..." from menu, will throw a `NullReferenceException`.
I added null check into the event `Import_Click` and the issue was fixed. Please have a check.

Thanks,
Chang